### PR TITLE
Update drawing-tools.html

### DIFF
--- a/apps/drawing-tools.html
+++ b/apps/drawing-tools.html
@@ -64,8 +64,8 @@
           </div>
           <select class="custom-select" id="codeLength">
             <option value="8">8</option>
-            <option value="10" selected>10</option>
-            <option value="11">11</option>
+            <option value="10">10</option>
+            <option value="11" selected>11</option>
             <option value="12">12</option>
             <option value="13">13</option>
             <option value="14">14</option>


### PR DESCRIPTION
Updating the default value in the UBID-length dropdown list of the visualizer website to be 11 instead of 10 to match our recommended length when creating UBID's for users.